### PR TITLE
Fix resource leaks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 */build/
 old/
 /build/
+.settings/
+.project
+.classpath

--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,8 @@ subprojects {
 	
 	apply plugin: 'java'
 	
+	sourceCompatibility = 1.8
+
 	task sourcesJar(type:Jar){
 		from sourceSets.main.allSource
 		classifier = 'source'

--- a/net.akehurst.build.gradle.equinox/src/main/java/net/akehurst/build/gradle/equinox/Converter.java
+++ b/net.akehurst.build.gradle.equinox/src/main/java/net/akehurst/build/gradle/equinox/Converter.java
@@ -30,8 +30,7 @@ public class Converter {
 	public static void osgify(File jarFile, String symbolicName, String outputDir) throws Exception {
 		Logger log = Logging.getLogger(Converter.class);
 		
-		try {
-			JarFile jar = new JarFile(jarFile);
+		try (JarFile jar = new JarFile(jarFile)) {
 			Manifest m = jar.getManifest();
 			if (null==m) {
 				m = new Manifest();

--- a/net.akehurst.build.gradle.equinox/src/main/java/net/akehurst/build/gradle/equinox/Converter.java
+++ b/net.akehurst.build.gradle.equinox/src/main/java/net/akehurst/build/gradle/equinox/Converter.java
@@ -15,27 +15,36 @@
  */
 package net.akehurst.build.gradle.equinox;
 
-import java.io.*;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.*;
-import java.util.jar.*;
-import org.slf4j.Logger;
+import java.util.Enumeration;
+import java.util.jar.Attributes;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
+import java.util.jar.JarOutputStream;
+import java.util.jar.Manifest;
 
-import org.gradle.api.logging.*;
+import org.gradle.api.logging.Logging;
+import org.slf4j.Logger;
 
 public class Converter {
 
 	public static void osgify(File jarFile, String symbolicName, String outputDir) throws Exception {
 		Logger log = Logging.getLogger(Converter.class);
-		
+
 		try (JarFile jar = new JarFile(jarFile)) {
 			Manifest m = jar.getManifest();
 			if (null==m) {
 				m = new Manifest();
 			}
-			
+
 			Path destinationPath = Paths.get(outputDir).resolve(jarFile.getName());
 			if (destinationPath.toFile().exists()) {
 				destinationPath.toFile().delete();
@@ -51,7 +60,7 @@ public class Converter {
 				//create osgi manifest entries
 				att.putValue("Manifest-Version", "1.0");
 				att.putValue("Bundle-SymbolicName", symbolicName);
-				
+
 				String exportPackages = "";
 				Enumeration<JarEntry> entries = jar.entries();
 				while(entries.hasMoreElements()){
@@ -66,7 +75,7 @@ public class Converter {
 				att.putValue("Export-Package", exportPackages);
 
 				//create new jar
-				
+
 				FileOutputStream out = new FileOutputStream(destinationPath.toFile());
 				JarOutputStream jarOut = new JarOutputStream(out, m);
 				entries = jar.entries();
@@ -80,24 +89,24 @@ public class Converter {
 						copy(ins,jarOut);
 					}
 				}
-				
-				
+
+
 				jarOut.close();
 			}
 		} catch (Exception ex) {
 			ex.printStackTrace();
 		}
-		
-		
+
+
 	}
-	
+
 	static String fetchPackageName(JarEntry je) {
 		String n = je.getName();
 		int i = n.lastIndexOf('/');
 		n = n.substring(0, i);
 		return n;
 	}
-	
+
 	static void copy(InputStream ins, OutputStream outs) {
 	    try{
             byte[] bytes = new byte[10*1024];
@@ -113,5 +122,5 @@ public class Converter {
             ex.printStackTrace();
         }
 	}
-	
+
 }

--- a/net.akehurst.build.gradle.resolver.p2/build.gradle
+++ b/net.akehurst.build.gradle.resolver.p2/build.gradle
@@ -33,7 +33,7 @@ dependencies {
 }
 
 pluginBundle {
-  website = 'http://www.gradle.org/'
+  website = 'https://www.gradle.org/'
   vcsUrl = 'https://github.com/dhakehurst/net.akehurst.build.gradle'
   description = 'A plugin to enable gradle dependencies on p2 repositories.'
   tags = ['p2', 'dependency', 'eclipse']

--- a/net.akehurst.build.gradle.resolver.p2/src/main/java/net/akehurst/build/gradle/p2resolver/gradle/component/model/AbstractModuleComponentResolveMetaData.java
+++ b/net.akehurst.build.gradle.resolver.p2/src/main/java/net/akehurst/build/gradle/p2resolver/gradle/component/model/AbstractModuleComponentResolveMetaData.java
@@ -43,8 +43,6 @@ import com.google.common.collect.LinkedHashMultimap;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Multimap;
 
-import net.akehurst.build.gradle.resolver.p2.P2ModuleResolveMetaData;
-
 public
 abstract
 class AbstractModuleComponentResolveMetaData extends AbstractModuleDescriptorBackedMetaData implements MutableModuleComponentResolveMetaData {

--- a/net.akehurst.build.gradle.resolver.p2/src/main/java/net/akehurst/build/gradle/resolver/p2/AbstractP2RepositoryAccess.java
+++ b/net.akehurst.build.gradle.resolver.p2/src/main/java/net/akehurst/build/gradle/resolver/p2/AbstractP2RepositoryAccess.java
@@ -18,29 +18,22 @@ package net.akehurst.build.gradle.resolver.p2;
 import java.io.File;
 import java.net.URI;
 import java.nio.file.Paths;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
-import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.jar.Attributes;
 import java.util.jar.JarFile;
 import java.util.jar.Manifest;
 
+import net.akehurst.build.resolver.p2.OsgiP2ResolverException;
+
 import org.apache.ivy.core.module.descriptor.Configuration;
-import org.apache.ivy.core.module.descriptor.DefaultDependencyArtifactDescriptor;
-import org.apache.ivy.core.module.descriptor.DefaultDependencyDescriptor;
 import org.apache.ivy.core.module.descriptor.DefaultModuleDescriptor;
-import org.apache.ivy.core.module.descriptor.DependencyDescriptor;
 import org.apache.ivy.core.module.descriptor.MDArtifact;
 import org.apache.ivy.core.module.id.ModuleId;
 import org.apache.ivy.core.module.id.ModuleRevisionId;
-import org.eclipse.osgi.util.ManifestElement;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
-import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.CachingModuleComponentRepository;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.ModuleComponentRepositoryAccess;
 import org.gradle.api.internal.component.ArtifactType;
 import org.gradle.internal.component.external.model.ModuleComponentArtifactMetaData;
@@ -49,7 +42,6 @@ import org.gradle.internal.component.model.ComponentArtifactMetaData;
 import org.gradle.internal.component.model.ComponentOverrideMetadata;
 import org.gradle.internal.component.model.ComponentResolveMetaData;
 import org.gradle.internal.component.model.ComponentUsage;
-import org.gradle.internal.component.model.ConfigurationMetaData;
 import org.gradle.internal.component.model.DependencyMetaData;
 import org.gradle.internal.component.model.ModuleSource;
 import org.gradle.internal.resolve.ArtifactResolveException;
@@ -58,14 +50,10 @@ import org.gradle.internal.resolve.result.BuildableArtifactResolveResult;
 import org.gradle.internal.resolve.result.BuildableArtifactSetResolveResult;
 import org.gradle.internal.resolve.result.BuildableModuleComponentMetaDataResolveResult;
 import org.gradle.internal.resolve.result.BuildableModuleVersionListingResolveResult;
-import org.osgi.framework.BundleException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.yaml.snakeyaml.DumperOptions.Version;
 
 import com.google.common.collect.ImmutableSet;
-
-import net.akehurst.build.resolver.p2.OsgiP2ResolverException;
 
 abstract public class AbstractP2RepositoryAccess implements ModuleComponentRepositoryAccess {
 
@@ -76,10 +64,10 @@ abstract public class AbstractP2RepositoryAccess implements ModuleComponentRepos
 	abstract public Set<String> getVersions(String artifactId) throws OsgiP2ResolverException;
 
 	abstract public URI fetchArtifact(String artifactId, String versionRangeString) throws OsgiP2ResolverException;
-	
-	
+
+
 	String gradleToOsgiVersion(String gradleVersionString) {
-		
+
 		if ("+".equals(gradleVersionString)) {
 			return "0.0.0";
 		} else if (gradleVersionString.endsWith("+")) {
@@ -89,12 +77,12 @@ abstract public class AbstractP2RepositoryAccess implements ModuleComponentRepos
 			//strict version
 			return "["+gradleVersionString+","+gradleVersionString+"]";
 		}
-		
+
 	}
-	
+
 	void addDependencies(DefaultModuleDescriptor moduleDescriptor, String group, Manifest manifest) {
 		//can't resolve dependencies because the resolution of dependencies doesn't seem to look in the p2 resolver!
-		
+
 //		try {
 //			List<DependencyDescriptor> list = new ArrayList<>();
 //			Attributes atts = manifest.getMainAttributes();
@@ -248,7 +236,7 @@ abstract public class AbstractP2RepositoryAccess implements ModuleComponentRepos
 		LOG.trace("resolveConfigurationArtifacts");
         ModuleComponentArtifactMetaData artifact = module.artifact("jar", "jar", null);
         result.resolved(ImmutableSet.of(artifact));
-        
+
 	}
 
 	protected void resolveMetaDataArtifacts(ModuleComponentResolveMetaData module, BuildableArtifactSetResolveResult result) {
@@ -266,6 +254,6 @@ abstract public class AbstractP2RepositoryAccess implements ModuleComponentRepos
 	protected void resolveSourceArtifacts(ModuleComponentResolveMetaData module, BuildableArtifactSetResolveResult result) {
 		LOG.trace("resolveSourceArtifacts");
 		result.resolved(Collections.emptySet());
-		
+
 	}
 }

--- a/net.akehurst.build.gradle.resolver.p2/src/main/java/net/akehurst/build/gradle/resolver/p2/DefaultP2Resolver.java
+++ b/net.akehurst.build.gradle.resolver.p2/src/main/java/net/akehurst/build/gradle/resolver/p2/DefaultP2Resolver.java
@@ -19,13 +19,13 @@ import java.net.URI;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
+import net.akehurst.build.resolver.p2.SimpleOsgiP2Resolver;
+import net.akehurst.build.resolver.p2.osgi.SimpleOsgi;
+
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.ConfiguredModuleComponentRepository;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.ModuleComponentRepositoryAccess;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
-
-import net.akehurst.build.resolver.p2.osgi.SimpleOsgi;
-import net.akehurst.build.resolver.p2.SimpleOsgiP2Resolver;
 
 public class DefaultP2Resolver implements ConfiguredModuleComponentRepository {
 

--- a/net.akehurst.build.gradle.resolver.p2/src/main/java/net/akehurst/build/gradle/resolver/p2/P2LocalRepositoryAccess.java
+++ b/net.akehurst.build.gradle.resolver.p2/src/main/java/net/akehurst/build/gradle/resolver/p2/P2LocalRepositoryAccess.java
@@ -16,27 +16,22 @@
 package net.akehurst.build.gradle.resolver.p2;
 
 import java.net.URI;
-import java.util.Collections;
 import java.util.Set;
 
+import net.akehurst.build.resolver.p2.OsgiP2ResolverException;
+
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
-import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.ModuleComponentRepositoryAccess;
 import org.gradle.api.internal.component.ArtifactType;
-import org.gradle.internal.component.external.model.ModuleComponentResolveMetaData;
 import org.gradle.internal.component.model.ComponentArtifactMetaData;
 import org.gradle.internal.component.model.ComponentOverrideMetadata;
 import org.gradle.internal.component.model.ComponentResolveMetaData;
 import org.gradle.internal.component.model.ComponentUsage;
-import org.gradle.internal.component.model.DependencyMetaData;
 import org.gradle.internal.component.model.ModuleSource;
 import org.gradle.internal.resolve.result.BuildableArtifactResolveResult;
 import org.gradle.internal.resolve.result.BuildableArtifactSetResolveResult;
 import org.gradle.internal.resolve.result.BuildableModuleComponentMetaDataResolveResult;
-import org.gradle.internal.resolve.result.BuildableModuleVersionListingResolveResult;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import net.akehurst.build.resolver.p2.OsgiP2ResolverException;
 
 public class P2LocalRepositoryAccess extends AbstractP2RepositoryAccess
 {

--- a/net.akehurst.build.gradle.resolver.p2/src/main/java/net/akehurst/build/gradle/resolver/p2/P2ModuleResolveMetaData.java
+++ b/net.akehurst.build.gradle.resolver.p2/src/main/java/net/akehurst/build/gradle/resolver/p2/P2ModuleResolveMetaData.java
@@ -16,25 +16,18 @@
 package net.akehurst.build.gradle.resolver.p2;
 
 import java.util.Date;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+
+import net.akehurst.build.gradle.p2resolver.gradle.component.model.AbstractModuleComponentResolveMetaData;
 
 import org.apache.ivy.core.module.descriptor.DefaultModuleDescriptor;
 import org.apache.ivy.core.module.descriptor.ModuleDescriptor;
 import org.apache.ivy.core.module.id.ModuleId;
 import org.apache.ivy.core.module.id.ModuleRevisionId;
-import org.gradle.api.internal.artifacts.ivyservice.NamespaceId;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
-import org.gradle.internal.component.external.model.IvyModuleResolveMetaData;
 import org.gradle.internal.component.external.model.MavenModuleResolveMetaData;
 import org.gradle.internal.component.external.model.MutableModuleComponentResolveMetaData;
-import org.gradle.internal.component.model.DependencyMetaData;
 import org.gradle.internal.component.model.ModuleSource;
-
-//import org.gradle.internal.component.external.model.AbstractModuleComponentResolveMetaData; 
-import net.akehurst.build.gradle.p2resolver.gradle.component.model.AbstractModuleComponentResolveMetaData;
 
 //Must implement either IvyModuleResolveMetaData or MavenModuleResolveMetaData
 //otherwise gradle rejects the repository type

--- a/net.akehurst.build.gradle.resolver.p2/src/main/java/net/akehurst/build/gradle/resolver/p2/P2RemoteRepositoryAccess.java
+++ b/net.akehurst.build.gradle.resolver.p2/src/main/java/net/akehurst/build/gradle/resolver/p2/P2RemoteRepositoryAccess.java
@@ -18,10 +18,10 @@ package net.akehurst.build.gradle.resolver.p2;
 import java.net.URI;
 import java.util.Set;
 
+import net.akehurst.build.resolver.p2.OsgiP2ResolverException;
+
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
-
-import net.akehurst.build.resolver.p2.OsgiP2ResolverException;
 
 public class P2RemoteRepositoryAccess extends AbstractP2RepositoryAccess {
 

--- a/net.akehurst.build.gradle.resolver.p2/src/main/java/net/akehurst/build/gradle/resolver/p2/P2ResolverPlugin.java
+++ b/net.akehurst.build.gradle.resolver.p2/src/main/java/net/akehurst/build/gradle/resolver/p2/P2ResolverPlugin.java
@@ -19,8 +19,6 @@ import java.io.IOException;
 import java.net.URL;
 import java.net.URLClassLoader;
 
-import org.eclipse.osgi.internal.framework.EquinoxConfiguration;
-import org.eclipse.osgi.internal.framework.EquinoxContainer;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.logging.Logger;
@@ -30,13 +28,14 @@ import org.gradle.internal.classloader.MutableURLClassLoader;
 class P2ResolverPlugin implements Plugin<Project> {
 	 private final static Logger LOG = Logging.getLogger(P2ResolverPlugin.class);
 
+	@Override
 	public void apply(Project project) {
-		LOG.trace("apply");		
-		
+		LOG.trace("apply");
+
 		//The plugin class loader is an isolated descendant of the classloader that
 		// does the dependency resolution. So we need to mess with the classloaders
 		// in order to get the P2 resolver classes to load appropriately
-		
+
 		//get the current class loader
 		Thread thread = Thread.currentThread();
 		ClassLoader contextClassLoader = thread.getContextClassLoader();
@@ -49,9 +48,9 @@ class P2ResolverPlugin implements Plugin<Project> {
 		try (MutableURLClassLoader cl = (MutableURLClassLoader)toUse; URLClassLoader plCl = (URLClassLoader)contextClassLoader) {
 			for(URL location: plCl.getURLs()) {
 				cl.addURL(location );
-				LOG.trace("Adding URL to class loader: "+location);				
+				LOG.trace("Adding URL to class loader: "+location);
 			}
-			
+
 //			//add url of this plugin to the jars searchable by the 'toUse' classLoader
 //			URL location = this.getClass().getProtectionDomain().getCodeSource().getLocation();
 //			cl.addURL(location );
@@ -59,12 +58,12 @@ class P2ResolverPlugin implements Plugin<Project> {
 
 			Class<?> cls = toUse.loadClass("net.akehurst.build.gradle.resolver.p2.DefaultResolverHandler");
 		    project.getExtensions().create("resolvers", cls, project);
-		    
+
 		} catch (ClassNotFoundException | IOException e) {
 
 			e.printStackTrace();
 		}
-		
+
 	}
 
 }

--- a/net.akehurst.build.gradle.resolver.p2/src/main/java/net/akehurst/build/gradle/resolver/p2/P2ResolverPlugin.java
+++ b/net.akehurst.build.gradle.resolver.p2/src/main/java/net/akehurst/build/gradle/resolver/p2/P2ResolverPlugin.java
@@ -15,7 +15,9 @@
  */
 package net.akehurst.build.gradle.resolver.p2;
 
+import java.io.IOException;
 import java.net.URL;
+import java.net.URLClassLoader;
 
 import org.eclipse.osgi.internal.framework.EquinoxConfiguration;
 import org.eclipse.osgi.internal.framework.EquinoxContainer;
@@ -44,10 +46,7 @@ class P2ResolverPlugin implements Plugin<Project> {
 		while(null!=toUse.getParent() && !(toUse instanceof MutableURLClassLoader)) {
 			toUse = toUse.getParent();
 		}
-		MutableURLClassLoader cl = (MutableURLClassLoader)toUse;
-		try {
-
-			java.net.URLClassLoader plCl = (java.net.URLClassLoader)contextClassLoader;
+		try (MutableURLClassLoader cl = (MutableURLClassLoader)toUse; URLClassLoader plCl = (URLClassLoader)contextClassLoader) {
 			for(URL location: plCl.getURLs()) {
 				cl.addURL(location );
 				LOG.trace("Adding URL to class loader: "+location);				
@@ -61,7 +60,7 @@ class P2ResolverPlugin implements Plugin<Project> {
 			Class<?> cls = toUse.loadClass("net.akehurst.build.gradle.resolver.p2.DefaultResolverHandler");
 		    project.getExtensions().create("resolvers", cls, project);
 		    
-		} catch (ClassNotFoundException e) {
+		} catch (ClassNotFoundException | IOException e) {
 
 			e.printStackTrace();
 		}


### PR DESCRIPTION
I had a look over the source code and noticed a few resource leaks (with findbugs).

The second commit documents that this plugin does not compile with Java 7 and because Gradle 3 requires at least Java 7 I set this up to require Java 8.

The third commit cleaned up lots of warnings (eclipse likes to do these changes on it's own).

If you dislike some of the changes / disagree with them you should be able to just cherry-pick the others.
I can also update this PR of course.

The source code doesn't have a consistent code style. There is a Gradle plugin that can enforce a consistent code style: [https://plugins.gradle.org/plugin/com.diffplug.gradle.spotless](https://plugins.gradle.org/plugin/com.diffplug.gradle.spotless). Spotless can also use an eclipse formatter profile.

WDYT about formatting the source, and applying spotless with your favorite formatting definition?
